### PR TITLE
Node12でのみCI/CDを実行する

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Fixes #21 

複数バージョンで実行できなくてもよく、buildできればいいので最新LTSのNode.js 12.xでのみCI/CDを回す。