### PR TITLE
時間管理機能改善

### DIFF
--- a/src/components/BulletinBoard.vue
+++ b/src/components/BulletinBoard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="root">
-    <h2>{{ runningTask.title }}</h2>
+    <h2>{{ runningTask.task.title }}</h2>
     <h3>
       {{ ellapsedTime.hours }}:{{
         `${ellapsedTime.minutes}`.padStart(2, "0")

--- a/src/components/BulletinBoard.vue
+++ b/src/components/BulletinBoard.vue
@@ -50,8 +50,8 @@ const useStopTimer = () => {
   return stopTimer;
 };
 
-const TaskList = defineComponent({
-  name: "TaskList",
+const BulletinBoard = defineComponent({
+  name: "BulletinBoard",
   props: {
     runningTask: Object,
     startedAt: Date,
@@ -62,7 +62,7 @@ const TaskList = defineComponent({
     return { ellapsedTime, stopTimer };
   },
 });
-export default TaskList;
+export default BulletinBoard;
 </script>
 
 <style scoped lang="scss">

--- a/src/components/BulletinBoard.vue
+++ b/src/components/BulletinBoard.vue
@@ -11,7 +11,12 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onMounted, reactive } from "@vue/composition-api";
+import {
+  defineComponent,
+  onMounted,
+  reactive,
+  onUnmounted,
+} from "@vue/composition-api";
 
 import { Task } from "@/domain/entity";
 import { useTaskStore } from "../composables/use_store";
@@ -39,14 +44,18 @@ const useEllapsedTime = (
   startedAt: Date
 ): { hours: number; minutes: number; seconds: number } => {
   const ellapsedTime = reactive(calcEllapsedTime(new Date(), startedAt));
+  let timer: number;
 
   onMounted(() => {
-    setInterval(() => {
+    timer = setInterval(() => {
       const newEllapsedTime = calcEllapsedTime(new Date(), startedAt);
       ellapsedTime.hours = newEllapsedTime.hours;
       ellapsedTime.minutes = newEllapsedTime.minutes;
       ellapsedTime.seconds = newEllapsedTime.seconds;
     }, 1000);
+  });
+  onUnmounted(() => {
+    clearInterval(timer);
   });
   return ellapsedTime;
 };

--- a/src/components/BulletinBoard.vue
+++ b/src/components/BulletinBoard.vue
@@ -2,9 +2,9 @@
   <div class="root">
     <h2>{{ runningTask.title }}</h2>
     <h3>
-      {{ ellapsedTime.hours }}:{{ ellapsedTime.minutes }}:{{
-        ellapsedTime.seconds
-      }}
+      {{ ellapsedTime.hours }}:{{
+        `${ellapsedTime.minutes}`.padStart(2, "0")
+      }}:{{ `${ellapsedTime.seconds}`.padStart(2, "0") }}
     </h3>
     <button @click="stopTimer">STOP</button>
   </div>
@@ -12,31 +12,40 @@
 
 <script lang="ts">
 import { defineComponent, onMounted, reactive } from "@vue/composition-api";
+
+import { Task } from "@/domain/entity";
 import { useTaskStore } from "../composables/use_store";
 
 interface Props {
-  startedAt: Date;
+  runningTask: { task: Task; startedAt: Date };
 }
+
+const calcEllapsedTime = (
+  now: Date,
+  start: Date
+): { hours: number; minutes: number; seconds: number } => {
+  const ellapsedMillisec = new Date().getTime() - start.getTime();
+  const hours = Math.floor(ellapsedMillisec / (60 * 60 * 1000));
+  const minutes = Math.floor(ellapsedMillisec / (60 * 1000)) % 60;
+  const seconds = Math.floor(ellapsedMillisec / 1000) % 60;
+  return {
+    hours,
+    minutes,
+    seconds,
+  };
+};
 
 const useEllapsedTime = (
   startedAt: Date
 ): { hours: number; minutes: number; seconds: number } => {
-  const ellapsedTime = reactive<{
-    hours: number;
-    minutes: number;
-    seconds: number;
-  }>({
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
-  });
+  const ellapsedTime = reactive(calcEllapsedTime(new Date(), startedAt));
 
   onMounted(() => {
     setInterval(() => {
-      const ellapsedMillisec = new Date().getTime() - startedAt.getTime();
-      ellapsedTime.hours = Math.floor(ellapsedMillisec / (60 * 60 * 1000));
-      ellapsedTime.minutes = Math.floor(ellapsedMillisec / (60 * 1000)) % 60;
-      ellapsedTime.seconds = Math.floor(ellapsedMillisec / 1000) % 60;
+      const newEllapsedTime = calcEllapsedTime(new Date(), startedAt);
+      ellapsedTime.hours = newEllapsedTime.hours;
+      ellapsedTime.minutes = newEllapsedTime.minutes;
+      ellapsedTime.seconds = newEllapsedTime.seconds;
     }, 1000);
   });
   return ellapsedTime;
@@ -54,10 +63,9 @@ const BulletinBoard = defineComponent({
   name: "BulletinBoard",
   props: {
     runningTask: Object,
-    startedAt: Date,
   },
   setup(props: Props) {
-    const ellapsedTime = useEllapsedTime(props.startedAt);
+    const ellapsedTime = useEllapsedTime(props.runningTask.startedAt);
     const stopTimer = useStopTimer();
     return { ellapsedTime, stopTimer };
   },

--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="task">
     <div>{{ task.title }}</div>
+    <div>Total: {{ totalTimeSpent }} minutes</div>
     <button @click="toggleTimer(isRunning)">
       {{ isRunning ? "STOP" : "START" }}
     </button>
@@ -42,9 +43,15 @@ const TaskCard = defineComponent({
     const isRunning = computed(() => {
       return props.runningTask && props.task.id === props.runningTask.task.id;
     });
+    const taskStore = useTaskStore();
+    const totalTimeSpent = computed(() => {
+      const totalMillisec = taskStore.calcTotalTimeSpentById(props.task.id);
+      return Math.floor(totalMillisec / (60 * 1000));
+    });
     return {
       toggleTimer,
       isRunning,
+      totalTimeSpent,
     };
   },
 });

--- a/src/components/TaskCard.vue
+++ b/src/components/TaskCard.vue
@@ -14,7 +14,7 @@ import { useTaskStore } from "../composables/use_store";
 
 interface Props {
   task: Task;
-  runningTask: Task;
+  runningTask: { task: Task; startedAt: Date };
 }
 
 export const useTimer = (taskId: string) => {
@@ -40,7 +40,7 @@ const TaskCard = defineComponent({
   setup(props: Props) {
     const { toggleTimer } = useTimer(props.task.id);
     const isRunning = computed(() => {
-      return props.runningTask && props.task.id === props.runningTask.id;
+      return props.runningTask && props.task.id === props.runningTask.task.id;
     });
     return {
       toggleTimer,

--- a/src/domain/entity/task_event.ts
+++ b/src/domain/entity/task_event.ts
@@ -1,4 +1,5 @@
 import { InvalidArgumentError } from "@/errors";
+import { assertIsDefined } from "@/lib/assert";
 
 export class TaskEvent {
   constructor(
@@ -34,5 +35,17 @@ export class TaskEvent {
       throw new InvalidArgumentError(`endedAt should not be before startedAt`);
     }
     this._endedAt = newDate;
+  }
+
+  get isEnded(): boolean {
+    return !!this.endedAt;
+  }
+
+  get duration(): number {
+    if (!this.isEnded) {
+      throw new Error("endedAt is not set yet");
+    }
+    assertIsDefined(this.endedAt);
+    return this.endedAt.getTime() - this.startedAt.getTime();
   }
 }

--- a/src/store/task.ts
+++ b/src/store/task.ts
@@ -88,14 +88,19 @@ export class TaskStore extends VuexModule {
     return this.taskEvents.find((event) => !event.endedAt);
   }
 
-  get runningTask(): Task | null {
+  get runningTask(): { task: Task; startedAt: Date } | null {
     const maybeIncompleteTaskEvent = this.incompleteTaskEvent;
     if (!maybeIncompleteTaskEvent) {
       return null;
     }
-    return (
-      this.tasks.find((task) => task.id === maybeIncompleteTaskEvent.taskId) ||
-      null
+    const task = this.tasks.find(
+      (task) => task.id === maybeIncompleteTaskEvent.taskId
     );
+    return task
+      ? {
+          task,
+          startedAt: maybeIncompleteTaskEvent.startedAt,
+        }
+      : null;
   }
 }

--- a/src/store/task.ts
+++ b/src/store/task.ts
@@ -103,4 +103,13 @@ export class TaskStore extends VuexModule {
         }
       : null;
   }
+
+  get calcTotalTimeSpentById() {
+    return (taskId: string) => {
+      return this.taskEvents
+        .filter((event) => event.taskId === taskId && event.isEnded)
+        .map((event) => event.duration)
+        .reduce((a, b) => a + b, 0);
+    };
+  }
 }

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,10 +1,6 @@
 <template>
   <div class="home">
-    <BulletinBoard
-      v-if="runningTask"
-      :runningTask="runningTask"
-      :startedAt="new Date()"
-    />
+    <BulletinBoard v-if="runningTask" :runningTask="runningTask" />
     <TaskList :tasks="tasks" :runningTask="runningTask" />
     <div v-if="shouldShowAddForm">
       <AddTaskForm @cancel="hideAddForm" />


### PR DESCRIPTION
Fixes #35 

![image](https://user-images.githubusercontent.com/6002787/80916257-812a5c00-8d92-11ea-8ec2-1c498ba1335c.png)

既知の問題として、タスクイベントを50件しかとってきていないので、50件を超えると正しく計算されなくなる。→ 取得したタスクに紐付いた全てのタスクイベントを取得するようにする。